### PR TITLE
Corrigindo escala de equivalência do gastômetro

### DIFF
--- a/web/app/scripts/controllers/home.ctrl.js
+++ b/web/app/scripts/controllers/home.ctrl.js
@@ -93,15 +93,15 @@
             function setTextosEquivalentes(salariosMinimos, casasPopulares, cestasBasicas) {
               vm.textosEquivalentes = [
                 {
-                  texto: "milhões de salários mínimos",
+                  texto: "mil de salários mínimos",
                   valor: salariosMinimos
                 },
                 {
-                  texto: "mil casas populares",
+                  texto: "casas populares",
                   valor: casasPopulares
                 },
                 {
-                  texto: "milhões de cestas básicas",
+                  texto: "mil de cestas básicas",
                   valor: cestasBasicas
                 }
               ];


### PR DESCRIPTION
Um rapaz mandou uma mensagem no Facebook apontando que as escalas de salários mínimos do gastômetro estavam erradas. Estavam mesmo.